### PR TITLE
Add package.json to sample versionrc.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Here is an example configuration that updates the version, Android `versionCode`
 module.exports = {
   bumpFiles: [
     {
+      filename: 'package.json',
+    },
+    {
       filename: 'app.json',
       updater: require.resolve('standard-version-expo'),
     },


### PR DESCRIPTION
If versionrc.js is present, package.json isn't automatically bumped unless it's included in the versionrc.json config

Thanks for the plugin! I've been enjoying it
